### PR TITLE
Update to 0.9.1-1.1

### DIFF
--- a/SOURCES/0001-varstore-sb-state-only-load-auth-data-if-needed.patch
+++ b/SOURCES/0001-varstore-sb-state-only-load-auth-data-if-needed.patch
@@ -1,0 +1,47 @@
+From 769c28c6c3fe69436c2a26de2cf9c30a8ca8cbb2 Mon Sep 17 00:00:00 2001
+From: Bobby Eshleman <bobby.eshleman@gmail.com>
+Date: Wed, 23 Jun 2021 11:15:45 -0700
+Subject: [PATCH] varstore-sb-state: only load auth data if needed
+
+The loaded auth data is only necessary when calling varstore-sb-state
+user, so only call load_one_auth_data() if varstore-sb-state user is
+called.
+
+This avoids varstore-sb-state ${uuid} setup from attempting to load auth
+files, which it doesn't actually need, and therefore avoids complaints
+if there happens to be a missing auth file.
+
+Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>
+---
+ tools/varstore-sb-state.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tools/varstore-sb-state.c b/tools/varstore-sb-state.c
+index dc91b2b..914d9f9 100644
+--- a/tools/varstore-sb-state.c
++++ b/tools/varstore-sb-state.c
+@@ -92,8 +92,6 @@ int main(int argc, char **argv)
+     if (opt_socket)
+         db->parse_arg("socket", opt_socket);
+ 
+-    load_auth_data();
+-
+     if (!drop_privileges(opt_chroot, opt_depriv, opt_gid, opt_uid))
+         exit(1);
+ 
+@@ -110,8 +108,10 @@ int main(int argc, char **argv)
+     printf("Removing dbx...\n");
+     do_rm(&gEfiImageSecurityDatabaseGuid, "dbx");
+ 
+-    if (!strcmp(argv[optind + 1], "user"))
++    if (!strcmp(argv[optind + 1], "user")) {
++        load_auth_data();
+         return setup_keys();
+-    else
++    } else {
+         return 0;
++    }
+ }
+-- 
+2.30.0
+

--- a/SPECS/varstored-tools.spec
+++ b/SPECS/varstored-tools.spec
@@ -1,6 +1,6 @@
 Name:           varstored-tools
 Version:        0.9.1
-Release:        1%{?dist}
+Release:        1.1%{?dist}
 Summary:        Variables store for UEFI guests
 License:        BSD
 URL:            https://github.com/xapi-project/varstored
@@ -11,6 +11,8 @@ BuildRequires:  gcc
 BuildRequires:  libxml2-devel
 BuildRequires:  libseccomp-devel
 BuildRequires:  openssl-devel
+
+Patch00: 0001-varstore-sb-state-only-load-auth-data-if-needed.patch
 
 %description
 Command-line utilities for varstored/uefistored
@@ -42,5 +44,8 @@ install -m 0755 create-auth %{buildroot}/opt/xensource/libexec/
 /opt/xensource/libexec/create-auth
 
 %changelog
+* Mon Jun 28 2021 Bobby Eshleman <bobbyeshleman@gmail.com> - 0.9.1-1.1
+- Change varstore-sb-state setup to not load auth data
+
 * Wed Nov 25 2020 Samuel Verschelde <stormi-xcp@ylix.fr> - 0.9.1-1
 - Initial XCP-ng build


### PR DESCRIPTION
Fixes the missing auth file warning when calling `varstore-sb-state setup`.