### PR TITLE
Update varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch

### DIFF
--- a/SOURCES/varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch
+++ b/SOURCES/varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch
@@ -1,4 +1,5 @@
-From 769c28c6c3fe69436c2a26de2cf9c30a8ca8cbb2 Mon Sep 17 00:00:00 2001
+From 8eae21743b1dd8b4f83feaaa115dae6046e65bf9 Mon Sep 17 00:00:00 2001
+Message-Id: <8eae21743b1dd8b4f83feaaa115dae6046e65bf9.1626397765.git.bobby.eshleman@gmail.com>
 From: Bobby Eshleman <bobby.eshleman@gmail.com>
 Date: Wed, 23 Jun 2021 11:15:45 -0700
 Subject: [PATCH] varstore-sb-state: only load auth data if needed
@@ -8,40 +9,28 @@ user, so only call load_one_auth_data() if varstore-sb-state user is
 called.
 
 This avoids varstore-sb-state ${uuid} setup from attempting to load auth
-files, which it doesn't actually need, and therefore avoids complaints
-if there happens to be a missing auth file.
+files, which it doesn't actually need, and therefore avoids unnecessary
+complaints if there happens to be one or more missing auth files.
 
 Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>
 ---
- tools/varstore-sb-state.c | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ tools/varstore-sb-state.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/tools/varstore-sb-state.c b/tools/varstore-sb-state.c
-index dc91b2b..914d9f9 100644
+index dc91b2b..6305dd2 100644
 --- a/tools/varstore-sb-state.c
 +++ b/tools/varstore-sb-state.c
-@@ -92,8 +92,6 @@ int main(int argc, char **argv)
+@@ -92,7 +92,8 @@ int main(int argc, char **argv)
      if (opt_socket)
          db->parse_arg("socket", opt_socket);
  
 -    load_auth_data();
--
++    if (!strcmp(argv[optind + 1], "user"))
++        load_auth_data();
+ 
      if (!drop_privileges(opt_chroot, opt_depriv, opt_gid, opt_uid))
          exit(1);
- 
-@@ -110,8 +108,10 @@ int main(int argc, char **argv)
-     printf("Removing dbx...\n");
-     do_rm(&gEfiImageSecurityDatabaseGuid, "dbx");
- 
--    if (!strcmp(argv[optind + 1], "user"))
-+    if (!strcmp(argv[optind + 1], "user")) {
-+        load_auth_data();
-         return setup_keys();
--    else
-+    } else {
-         return 0;
-+    }
- }
 -- 
 2.30.0
 

--- a/SPECS/varstored-tools.spec
+++ b/SPECS/varstored-tools.spec
@@ -1,6 +1,6 @@
 Name:           varstored-tools
 Version:        0.9.1
-Release:        1.1%{?dist}
+Release:        1.2%{?dist}
 Summary:        Variables store for UEFI guests
 License:        BSD
 URL:            https://github.com/xapi-project/varstored
@@ -45,6 +45,10 @@ install -m 0755 create-auth %{buildroot}/opt/xensource/libexec/
 /opt/xensource/libexec/create-auth
 
 %changelog
+* Thu July 15 2021 Bobby Eshleman <bobbyeshleman@gmail.com> - 0.9.1-1.2
+- Update varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch to
+  newest upstream commit
+
 * Mon Jun 28 2021 Bobby Eshleman <bobbyeshleman@gmail.com> - 0.9.1-1.1
 - Change varstore-sb-state setup to not load auth data
 - Patch varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch added


### PR DESCRIPTION
Previously, varstored-0.9.1-sb-state-only-load-auth-data-if-needed.XCP-ng.patch was
an out of tree patch.  This commit updates the patch to be, instead, the
commit that is now in upstream varstored.

Because xapi-project/varstored has yet to tag and release a release with
this commit included, and instead of creating our own mirror to tag and
release,  we're carrying the patch here.

This patch may be dropped when they tag/release varstored version >
1.0.0.